### PR TITLE
Added weighted RGB to color.Gray conversion

### DIFF
--- a/colorconv.go
+++ b/colorconv.go
@@ -226,6 +226,22 @@ func HexToRGB(hex string) (r, g, b uint8, err error) {
 	return r, g, b, nil
 }
 
+//RGBToGrayAverage calculates the grayscale value of RGB with the average method, ignoring the alpha channel.
+func RGBToGrayAverage(r, g, b uint8) color.Gray {
+	return RGBToGrayWithWeight(r, g, b, 1, 1, 1)
+}
+
+// RGBToGrayWithWeight calculates the grayscale value of RGB wih provided weight, ignoring the alpha channel.
+// In the standard library image/color, the conversion used the coefficient given by the JFIF specification. It is
+// equivalent to using the weight 299, 587, 114 for rgb.
+func RGBToGrayWithWeight(r, g, b uint8, rWeight, gWeight, bWeight uint) color.Gray {
+	rw := uint(r) * rWeight
+	gw := uint(g) * gWeight
+	bw := uint(b) * bWeight
+
+	return color.Gray{Y: uint8(math.Round(float64(rw+gw+bw) / float64(rWeight+gWeight+bWeight)))}
+}
+
 func hex2uint8(hexStr string) (uint8, error) {
 	// base 16 for hexadecimal
 	result, err := strconv.ParseUint(hexStr, 16, 8)


### PR DESCRIPTION
The color package has a [GrayModel](https://pkg.go.dev/image/color#Model) that can convert color.Color to color.Gray:
```go
c := color.NRGBA{
  R: 123,
  G: 210,
  B: 65,
  A: 255,
}
gray := color.GrayModel.Convert(c)
```

This conversion method used a [preset coefficients ](https://github.com/golang/go/blob/6d8ec893039a39f495c8139012e47754e4518b70/src/image/color/color.go#L244)given by the [JFIF specification ](https://www.w3.org/Graphics/JPEG/jfif3.pdf).

I added a method to convert RGB values to color.Gray with custom coefficiecnts(weight).