### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,15 +3,15 @@ name: Go
 on:
   push:
     branches:
-      - 'master'
-  pull_request:
-    branches:
       - '*'
     paths:
       - '**.go'
+      - '.github/workflows/go.yml'
+  pull_request:
+    branches:
+      - 'master'
 
 jobs:
-
   build:
     name: Test & Build
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,13 +3,13 @@ name: Go
 on:
   push:
     branches:
-      - master
+      - 'master'
   pull_request:
     branches:
-      - *
+      - '*'
     paths:
-      - "**.go"
-      - ".github/workflows/go.yml"
+      - '**.go'
+      - '.github/workflows/go.yml'
 
 jobs:
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
 
       - name: Set up Go 1.17
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v3.3.0
         with:
           go-version: '1.17'
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,14 @@ name: Go
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
+    branches:
+      - *
+    paths:
+      - "**.go"
+      - ".github/workflows/go.yml"
 
 jobs:
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,6 @@ on:
       - '*'
     paths:
       - '**.go'
-      - ".github/workflows/go.yml"
 
 jobs:
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,22 +12,13 @@ jobs:
     name: Test & Build
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code
+        uses: actions/checkout@v3
 
-      - name: Set up Go 1.15.3
+      - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.3
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Get dependencies
-        run: |
-          go get -v -t -d ./...
-          if [ -f Gopkg.toml ]; then
-              curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-              dep ensure
-          fi
+          go-version: '1.17'
 
       - name: Build
         run: go build -v .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ on:
       - '*'
     paths:
       - '**.go'
-      - '.github/workflows/go.yml'
+      - ".github/workflows/go.yml"
 
 jobs:
 

--- a/colorconv_test.go
+++ b/colorconv_test.go
@@ -11,12 +11,6 @@ func delta(x, y uint8) uint8 {
 	}
 	return y - x
 }
-func delta32(x, y uint32) uint32 {
-	if x >= y {
-		return x - y
-	}
-	return y - x
-}
 
 // TestValueOutOfRange tests that when inputs are out of range, an error occur
 func TestValueOutOfRange(t *testing.T) {


### PR DESCRIPTION
Pinned workflow actions dependencies.
Update workflow Go version to 1.17. This also meant removing go dep script because it is no longer needed with go mod support.

Note on why Go 1.17: While generics support in 1.18 might help in some helper functions, I want the code to compile in older code.